### PR TITLE
Return link to classifier to version 2020.8

### DIFF
--- a/16S.ipynb
+++ b/16S.ipynb
@@ -427,7 +427,7 @@
         "id": "drgYtfLbDosv"
       },
       "source": [
-        "!wget https://data.qiime2.org/2021.4/common/gg-13-8-99-515-806-nb-classifier.qza"
+        "!wget https://data.qiime2.org/2020.8/common/gg-13-8-99-515-806-nb-classifier.qza"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Return link to classifier file to 2020.8 version. This needs to stay the older version.