### PR TITLE
Return link to classifier to version 2020.8

### DIFF
--- a/16S_solutions.ipynb
+++ b/16S_solutions.ipynb
@@ -623,19 +623,19 @@
         }
       },
       "source": [
-        "!wget https://data.qiime2.org/2021.4/common/gg-13-8-99-515-806-nb-classifier.qza"
+        "!wget https://data.qiime2.org/2020.8/common/gg-13-8-99-515-806-nb-classifier.qza"
       ],
       "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "--2020-10-15 19:19:59--  https://data.qiime2.org/2021.4/common/gg-13-8-99-515-806-nb-classifier.qza\n",
+            "--2020-10-15 19:19:59--  https://data.qiime2.org/2020.8/common/gg-13-8-99-515-806-nb-classifier.qza\n",
             "Resolving data.qiime2.org (data.qiime2.org)... 52.35.38.247\n",
             "Connecting to data.qiime2.org (data.qiime2.org)|52.35.38.247|:443... connected.\n",
             "HTTP request sent, awaiting response... 302 FOUND\n",
-            "Location: https://s3-us-west-2.amazonaws.com/qiime2-data/2021.4/common/gg-13-8-99-515-806-nb-classifier.qza [following]\n",
-            "--2020-10-15 19:19:59--  https://s3-us-west-2.amazonaws.com/qiime2-data/2021.4/common/gg-13-8-99-515-806-nb-classifier.qza\n",
+            "Location: https://s3-us-west-2.amazonaws.com/qiime2-data/2020.8/common/gg-13-8-99-515-806-nb-classifier.qza [following]\n",
+            "--2020-10-15 19:19:59--  https://s3-us-west-2.amazonaws.com/qiime2-data/2020.8/common/gg-13-8-99-515-806-nb-classifier.qza\n",
             "Resolving s3-us-west-2.amazonaws.com (s3-us-west-2.amazonaws.com)... 52.218.234.0\n",
             "Connecting to s3-us-west-2.amazonaws.com (s3-us-west-2.amazonaws.com)|52.218.234.0|:443... connected.\n",
             "HTTP request sent, awaiting response... 200 OK\n",


### PR DESCRIPTION
Return link to classifier file to 2020.8 version. This needs to stay the older version.